### PR TITLE
Added an option to support specifying arbitrary table names

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,8 @@ var (
 	skipInit   bool
 	skipUpdate bool
 	cacheDir   string
+	vulnerabilitiesTableName   string
+	adivisoryTableName   string
 )
 
 var rootCmd = &cobra.Command{
@@ -58,12 +60,12 @@ var rootCmd = &cobra.Command{
 		}
 
 		if !skipInit {
-			if err := internal.InitDB(ctx, dsn); err != nil {
+			if err := internal.InitDB(ctx, dsn, vulnerabilitiesTableName, adivisoryTableName); err != nil {
 				return err
 			}
 		}
 
-		if err := internal.UpdateDB(ctx, cacheDir, dsn); err != nil {
+		if err := internal.UpdateDB(ctx, cacheDir, dsn, vulnerabilitiesTableName, adivisoryTableName); err != nil {
 			return err
 		}
 
@@ -92,6 +94,8 @@ func init() {
 	rootCmd.Flags().BoolVarP(&skipInit, "skip-init-db", "", false, "skip initializing target datasource")
 	rootCmd.Flags().BoolVarP(&skipUpdate, "skip-update", "", false, "skip updating Trivy DB")
 	rootCmd.Flags().StringVarP(&cacheDir, "cache-dir", "", "", "cache dir")
+	rootCmd.Flags().StringVarP(&vulnerabilitiesTableName, "vulnerabilities-table-name", "", "vulnerabilities", "Vulnerabilities Table Name")
+	rootCmd.Flags().StringVarP(&adivisoryTableName, "advisory-table-name", "", "vulnerability_advisories", "Vulnerability Advisories Table Name")
 }
 
 func cacheDirPath() string {

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -26,7 +26,6 @@ func New(db *sql.DB, vulnerabilitiesTableName, adivosryTableName string) (*Mysql
 func (m *Mysql) CreateIfNotExistTables(ctx context.Context) error {
 	var count int
 	stmt := fmt.Sprintf("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = database() AND table_name IN ('%s', '%s');", m.vulnerabilitiesTableName, m.adivosryTableName)
-	fmt.Printf(stmt)
 	if err := m.db.QueryRowContext(ctx, stmt).Scan(&count); err != nil {
 		return err
 	}

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -10,18 +10,24 @@ import (
 
 type Mysql struct {
 	db *sql.DB
+	vulnerabilitiesTableName string
+	adivosryTableName string
 }
 
 // New return *Mysql
-func New(db *sql.DB) (*Mysql, error) {
+func New(db *sql.DB, vulnerabilitiesTableName, adivosryTableName string) (*Mysql, error) {
 	return &Mysql{
 		db: db,
+		vulnerabilitiesTableName: vulnerabilitiesTableName,
+		adivosryTableName: adivosryTableName,
 	}, nil
 }
 
 func (m *Mysql) CreateIfNotExistTables(ctx context.Context) error {
 	var count int
-	if err := m.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = database() AND table_name IN ('vulnerabilities', 'vulnerability_advisories');`).Scan(&count); err != nil {
+	stmt := fmt.Sprintf("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = database() AND table_name IN ('%s', '%s');", m.vulnerabilitiesTableName, m.adivosryTableName)
+	fmt.Printf(stmt)
+	if err := m.db.QueryRowContext(ctx, stmt).Scan(&count); err != nil {
 		return err
 	}
 	switch count {
@@ -31,20 +37,24 @@ func (m *Mysql) CreateIfNotExistTables(ctx context.Context) error {
 		return errors.New("invalid table schema")
 	}
 
-	if _, err := m.db.Exec(`CREATE TABLE vulnerabilities (
+	stmt = fmt.Sprintf(`CREATE TABLE %s (
 id int PRIMARY KEY AUTO_INCREMENT,
 vulnerability_id varchar (25) NOT NULL,
 value json NOT NULL,
 created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
-) COMMENT = 'vulnerabilities obtained via Trivy DB' ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`); err != nil {
+) COMMENT = 'vulnerabilities obtained via Trivy DB' ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`, m.vulnerabilitiesTableName)
+
+	if _, err := m.db.Exec(stmt); err != nil {
 		return err
 	}
 
-	if _, err := m.db.Exec(`CREATE INDEX v_vulnerability_id_idx ON vulnerabilities(vulnerability_id) USING BTREE;`); err != nil {
+	stmt = fmt.Sprintf(`CREATE INDEX v_vulnerability_id_idx ON %s(vulnerability_id) USING BTREE;`, m.vulnerabilitiesTableName)
+	if _, err := m.db.Exec(stmt); err != nil {
 		return err
 	}
 
-	if _, err := m.db.Exec(`CREATE TABLE vulnerability_advisories (
+
+	stmt = fmt.Sprintf(`CREATE TABLE %s (
 id int PRIMARY KEY AUTO_INCREMENT,
 vulnerability_id varchar (25) NOT NULL,
 platform varchar (50) NOT NULL,
@@ -52,27 +62,34 @@ segment varchar (50) NOT NULL,
 package varchar (100) NOT NULL,
 value json NOT NULL,
 created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
-) COMMENT = 'vulnerability advisories obtained via Trivy DB' ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`); err != nil {
+) COMMENT = 'vulnerability advisories obtained via Trivy DB' ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`, m.adivosryTableName)
+
+	if _, err := m.db.Exec(stmt); err != nil {
 		return err
 	}
 
-	if _, err := m.db.Exec(`CREATE INDEX va_vulnerability_advisories_idx ON vulnerability_advisories(vulnerability_id, platform, segment, package) USING BTREE;`); err != nil {
+	stmt = fmt.Sprintf(`CREATE INDEX va_vulnerability_advisories_idx ON %s(vulnerability_id, platform, segment, package) USING BTREE;`, m.adivosryTableName)
+	if _, err := m.db.Exec(stmt); err != nil {
 		return err
 	}
 
-	if _, err := m.db.Exec(`CREATE INDEX va_vulnerability_id_idx ON vulnerability_advisories(vulnerability_id) USING BTREE;`); err != nil {
+	stmt = fmt.Sprintf(`CREATE INDEX va_vulnerability_id_idx ON %s(vulnerability_id) USING BTREE;`, m.adivosryTableName)
+	if _, err := m.db.Exec(stmt); err != nil {
 		return err
 	}
 
-	if _, err := m.db.Exec(`CREATE INDEX va_platform_idx ON vulnerability_advisories(platform) USING BTREE;`); err != nil {
+	stmt = fmt.Sprintf(`CREATE INDEX va_platform_idx ON %s(platform) USING BTREE;`, m.adivosryTableName)
+	if _, err := m.db.Exec(stmt); err != nil {
 		return err
 	}
 
-	if _, err := m.db.Exec(`CREATE INDEX va_source_idx ON vulnerability_advisories(platform, segment) USING BTREE;`); err != nil {
+	stmt = fmt.Sprintf(`CREATE INDEX va_source_idx ON %s(platform, segment) USING BTREE;`, m.adivosryTableName)
+	if _, err := m.db.Exec(stmt); err != nil {
 		return err
 	}
 
-	if _, err := m.db.Exec(`CREATE INDEX va_source_package_idx ON vulnerability_advisories(platform, segment, package) USING BTREE;`); err != nil {
+	stmt = fmt.Sprintf(`CREATE INDEX va_source_package_idx ON %s(platform, segment, package) USING BTREE;`, m.adivosryTableName)
+	if _, err := m.db.Exec(stmt); err != nil {
 		return err
 	}
 
@@ -80,7 +97,7 @@ created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
 }
 
 func (m *Mysql) InsertVuln(ctx context.Context, vulns [][][]byte) error {
-	query := fmt.Sprintf("INSERT INTO vulnerabilities(vulnerability_id,value) VALUES (?,?)%s", strings.Repeat(", (?,?)", len(vulns)-1)) // #nosec
+	query := fmt.Sprintf("INSERT INTO %s(vulnerability_id,value) VALUES (?,?)%s", m.vulnerabilitiesTableName, strings.Repeat(", (?,?)", len(vulns)-1)) // #nosec
 
 	ins, err := m.db.Prepare(query)
 	if err != nil {
@@ -98,7 +115,7 @@ func (m *Mysql) InsertVuln(ctx context.Context, vulns [][][]byte) error {
 }
 
 func (m *Mysql) InsertVulnAdvisory(ctx context.Context, vulnds [][][]byte) error {
-	query := fmt.Sprintf("INSERT INTO vulnerability_advisories(vulnerability_id,platform,segment,package,value) VALUES (?,?,?,?,?)%s", strings.Repeat(", (?,?,?,?,?)", len(vulnds)-1)) // #nosec
+	query := fmt.Sprintf("INSERT INTO %s(vulnerability_id,platform,segment,package,value) VALUES (?,?,?,?,?)%s", m.adivosryTableName, strings.Repeat(", (?,?,?,?,?)", len(vulnds)-1)) // #nosec
 	ins, err := m.db.Prepare(query)
 	if err != nil {
 		return err
@@ -115,14 +132,16 @@ func (m *Mysql) InsertVulnAdvisory(ctx context.Context, vulnds [][][]byte) error
 }
 
 func (m *Mysql) TruncateVulns(ctx context.Context) error {
-	if _, err := m.db.Exec(`TRUNCATE TABLE vulnerabilities;`); err != nil {
+	stmt := fmt.Sprintf("TRUNCATE TABLE %s;", m.vulnerabilitiesTableName)
+	if _, err := m.db.Exec(stmt); err != nil {
 		return err
 	}
 	return nil
 }
 
 func (m *Mysql) TruncateVulnAdvisories(ctx context.Context) error {
-	if _, err := m.db.Exec(`TRUNCATE TABLE vulnerability_advisories;`); err != nil {
+	stmt := fmt.Sprintf("TRUNCATE TABLE %s;", m.adivosryTableName)
+	if _, err := m.db.Exec(stmt); err != nil {
 		return err
 	}
 	return nil

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -10,18 +10,23 @@ import (
 
 type Postgres struct {
 	db *sql.DB
+	vulnerabilitiesTableName string
+	adivosryTableName string
 }
 
 // New return *Postgres
-func New(db *sql.DB) (*Postgres, error) {
+func New(db *sql.DB, vulnerabilitiesTableName, adivosryTableName string) (*Postgres, error) {
 	return &Postgres{
 		db: db,
+		vulnerabilitiesTableName: vulnerabilitiesTableName,
+		adivosryTableName: adivosryTableName,
 	}, nil
 }
 
 func (m *Postgres) CreateIfNotExistTables(ctx context.Context) error {
 	var count int
-	if err := m.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = current_schema() AND table_name IN ('vulnerabilities', 'vulnerability_advisories');`).Scan(&count); err != nil {
+	stmt := fmt.Sprintf("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = current_schema() AND table_name IN ('%s', '%s');", m.vulnerabilitiesTableName, m.adivosryTableName)
+	if err := m.db.QueryRowContext(ctx, stmt).Scan(&count); err != nil {
 		return err
 	}
 	switch count {
@@ -31,24 +36,29 @@ func (m *Postgres) CreateIfNotExistTables(ctx context.Context) error {
 		return errors.New("invalid table schema")
 	}
 
-	if _, err := m.db.Exec(`CREATE TABLE vulnerabilities (
+
+
+	stmt = fmt.Sprintf(`CREATE TABLE %s (
 id serial PRIMARY KEY,
 vulnerability_id varchar (25) NOT NULL,
 value json NOT NULL,
 created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
-)`); err != nil {
+)`, m.vulnerabilitiesTableName)
+	if _, err := m.db.Exec(stmt); err != nil {
 		return err
 	}
 
-	if _, err := m.db.Exec(`COMMENT ON TABLE vulnerabilities IS 'vulnerabilities obtained via Trivy DB';`); err != nil {
+	stmt = fmt.Sprintf("COMMENT ON TABLE %s IS 'vulnerability obtained via Trivy DB';", m.vulnerabilitiesTableName)
+	if _, err := m.db.Exec(stmt); err != nil {
 		return err
 	}
 
-	if _, err := m.db.Exec(`CREATE INDEX v_vulnerability_id_idx ON vulnerabilities(vulnerability_id);`); err != nil {
+	stmt = fmt.Sprintf("CREATE INDEX v_vulnerability_id_idx ON %s(vulnerability_id);", m.vulnerabilitiesTableName)
+	if _, err := m.db.Exec(stmt); err != nil {
 		return err
 	}
 
-	if _, err := m.db.Exec(`CREATE TABLE vulnerability_advisories (
+	stmt = fmt.Sprintf(`CREATE TABLE %s (
 id serial PRIMARY KEY,
 vulnerability_id varchar (25) NOT NULL,
 platform varchar (50) NOT NULL,
@@ -56,31 +66,38 @@ segment varchar (50) NOT NULL,
 package varchar (100) NOT NULL,
 value json NOT NULL,
 created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
-)`); err != nil {
+)`, m.adivosryTableName)
+	if _, err := m.db.Exec(stmt); err != nil {
 		return err
 	}
 
-	if _, err := m.db.Exec(`COMMENT ON TABLE vulnerability_advisories IS 'vulnerability advisories obtained via Trivy DB';`); err != nil {
+	stmt = fmt.Sprintf(`COMMENT ON TABLE %s IS 'vulnerability advisories obtained via Trivy DB';`, m.adivosryTableName)
+	if _, err := m.db.Exec(stmt); err != nil {
 		return err
 	}
 
-	if _, err := m.db.Exec(`CREATE INDEX va_vulnerability_advisories_idx ON vulnerability_advisories(vulnerability_id, platform, segment, package)`); err != nil {
+	stmt = fmt.Sprintf("CREATE INDEX va_vulnerability_advisories_idx ON %s(vulnerability_id, platform, segment, package)", m.adivosryTableName)
+	if _, err := m.db.Exec(stmt); err != nil {
 		return err
 	}
 
-	if _, err := m.db.Exec(`CREATE INDEX va_vulnerability_id_idx ON vulnerability_advisories(vulnerability_id)`); err != nil {
+	stmt = fmt.Sprintf("CREATE INDEX va_vulnerability_id_idx ON %s(vulnerability_id)", m.adivosryTableName)
+	if _, err := m.db.Exec(stmt); err != nil {
 		return err
 	}
 
-	if _, err := m.db.Exec(`CREATE INDEX va_platform_idx ON vulnerability_advisories(platform)`); err != nil {
+	stmt = fmt.Sprintf("CREATE INDEX va_platform_idx ON %s(platform)", m.adivosryTableName)
+	if _, err := m.db.Exec(stmt); err != nil {
 		return err
 	}
 
-	if _, err := m.db.Exec(`CREATE INDEX va_source_idx ON vulnerability_advisories(platform, segment)`); err != nil {
+	stmt = fmt.Sprintf("CREATE INDEX va_source_idx ON %s(platform, segment)", m.adivosryTableName)
+	if _, err := m.db.Exec(stmt); err != nil {
 		return err
 	}
 
-	if _, err := m.db.Exec(`CREATE INDEX va_source_package_idx ON vulnerability_advisories(platform, segment, package)`); err != nil {
+	stmt = fmt.Sprintf("CREATE INDEX va_source_package_idx ON %s(platform, segment, package)", m.adivosryTableName)
+	if _, err := m.db.Exec(stmt); err != nil {
 		return err
 	}
 
@@ -92,7 +109,7 @@ func (m *Postgres) InsertVuln(ctx context.Context, vulns [][][]byte) error {
 	for i := 0; i < len(vulns); i++ {
 		iv = append(iv, fmt.Sprintf("($%d, $%d)", i*2+1, i*2+2))
 	}
-	query := fmt.Sprintf("INSERT INTO vulnerabilities(vulnerability_id,value) VALUES %s", strings.Join(iv, ",")) // #nosec
+	query := fmt.Sprintf("INSERT INTO %s(vulnerability_id,value) VALUES %s", m.vulnerabilitiesTableName, strings.Join(iv, ",")) // #nosec
 
 	ins, err := m.db.Prepare(query)
 	if err != nil {
@@ -114,7 +131,7 @@ func (m *Postgres) InsertVulnAdvisory(ctx context.Context, vulnds [][][]byte) er
 	for i := 0; i < len(vulnds); i++ {
 		iv = append(iv, fmt.Sprintf("($%d, $%d, $%d, $%d, $%d)", i*5+1, i*5+2, i*5+3, i*5+4, i*5+5))
 	}
-	query := fmt.Sprintf("INSERT INTO vulnerability_advisories(vulnerability_id,platform,segment,package,value) VALUES %s", strings.Join(iv, ",")) // #nosec
+	query := fmt.Sprintf("INSERT INTO %s(vulnerability_id,platform,segment,package,value) VALUES %s", m.adivosryTableName, strings.Join(iv, ",")) // #nosec
 	ins, err := m.db.Prepare(query)
 	if err != nil {
 		return err
@@ -131,14 +148,16 @@ func (m *Postgres) InsertVulnAdvisory(ctx context.Context, vulnds [][][]byte) er
 }
 
 func (m *Postgres) TruncateVulns(ctx context.Context) error {
-	if _, err := m.db.Exec(`TRUNCATE TABLE vulnerabilities;`); err != nil {
+	stmt := fmt.Sprintf("TRUNCATE TABLE %s", m.vulnerabilitiesTableName)
+	if _, err := m.db.Exec(stmt); err != nil {
 		return err
 	}
 	return nil
 }
 
 func (m *Postgres) TruncateVulnAdvisories(ctx context.Context) error {
-	if _, err := m.db.Exec(`TRUNCATE TABLE vulnerability_advisories;`); err != nil {
+	stmt := fmt.Sprintf("TRUNCATE TABLE %s", m.adivosryTableName)
+	if _, err := m.db.Exec(stmt); err != nil {
 		return err
 	}
 	return nil

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -74,7 +74,7 @@ func InitDB(ctx context.Context, dsn, vulnerabilityTableName, advisoryTableName 
 			return err
 		}
 	case "postgres":
-		driver, err = postgres.New(db)
+		driver, err = postgres.New(db, vulnerabilityTableName, advisoryTableName)
 		if err != nil {
 			return err
 		}
@@ -112,7 +112,7 @@ func UpdateDB(ctx context.Context, cacheDir, dsn, vulnerabilityTableName, adviso
 			return err
 		}
 	case "postgres":
-		driver, err = postgres.New(db)
+		driver, err = postgres.New(db, vulnerabilityTableName, advisoryTableName)
 		if err != nil {
 			return err
 		}
@@ -127,7 +127,7 @@ func UpdateDB(ctx context.Context, cacheDir, dsn, vulnerabilityTableName, adviso
 	defer trivydb.Close()
 
 	if err := trivydb.View(func(tx *bolt.Tx) error {
-		_, _ = fmt.Fprintf(os.Stderr, "%s\n", ">> Updating table 'vulnerabilities' ... ")
+		_, _ = fmt.Fprintf(os.Stderr, ">> Updating table '%s' ...\n", vulnerabilityTableName)
 		if err := driver.TruncateVulns(ctx); err != nil {
 			return err
 		}
@@ -160,7 +160,7 @@ func UpdateDB(ctx context.Context, cacheDir, dsn, vulnerabilityTableName, adviso
 			}
 		}
 
-		_, _ = fmt.Fprintf(os.Stderr, "%s\n", ">> Update table 'vulnerability_advisories' ... ")
+		_, _ = fmt.Fprintf(os.Stderr, ">> Updating table '%s' ...\n", advisoryTableName)
 		if err := driver.TruncateVulnAdvisories(ctx); err != nil {
 			return err
 		}

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -52,7 +52,7 @@ func FetchTrivyDB(ctx context.Context, cacheDir string, light, quiet, skipUpdate
 	return nil
 }
 
-func InitDB(ctx context.Context, dsn string) error {
+func InitDB(ctx context.Context, dsn, vulnerabilityTableName, advisoryTableName string) error {
 	var (
 		driver drivers.Driver
 		err    error
@@ -69,7 +69,7 @@ func InitDB(ctx context.Context, dsn string) error {
 	defer db.Close()
 	switch u.Driver {
 	case "mysql":
-		driver, err = mysql.New(db)
+		driver, err = mysql.New(db, vulnerabilityTableName, advisoryTableName)
 		if err != nil {
 			return err
 		}
@@ -89,7 +89,7 @@ func InitDB(ctx context.Context, dsn string) error {
 	return nil
 }
 
-func UpdateDB(ctx context.Context, cacheDir, dsn string) error {
+func UpdateDB(ctx context.Context, cacheDir, dsn, vulnerabilityTableName, advisoryTableName string) error {
 	_, _ = fmt.Fprintf(os.Stderr, "%s", "Updating vulnerability information tables ... \n")
 	var (
 		driver drivers.Driver
@@ -107,7 +107,7 @@ func UpdateDB(ctx context.Context, cacheDir, dsn string) error {
 	defer db.Close()
 	switch u.Driver {
 	case "mysql":
-		driver, err = mysql.New(db)
+		driver, err = mysql.New(db, vulnerabilityTableName, advisoryTableName)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Add the `--vulnerability-table-name` and `--advisory-table-name` options to specify arbitrary table names. Defaults to `vulnerabilities` and `vulnerability_advisories`.

```
$ ./trivy-db-to --advisory-table-name 'trivy_vulnerability_advisories' --vulnerabilities-table-name 'trivy_vulnerabilities' 'postgresql://postgres:@127.0.0.1:5432/mytrivydb?sslmode=disable'
Fetching and updating Trivy DB ... done (already exist)
Initializing vulnerability information tables ... done
Updating vulnerability information tables ...
>> Updating table 'trivy_vulnerabilities' ...
>> Updating table 'trivy_vulnerability_advisories' ...
>>> GitHub Security Advisory Composer
>>> GitHub Security Advisory Maven
>>> GitHub Security Advisory Npm
>>> GitHub Security Advisory Nuget
>>> GitHub Security Advisory Pip
>>> GitHub Security Advisory Rubygems
...
>>> ubuntu 21.10
done

mytrivydb=# \dt
                     List of relations
 Schema |              Name              | Type  |  Owner
--------+--------------------------------+-------+----------
 public | trivy_vulnerabilities          | table | postgres
 public | trivy_vulnerability_advisories | table | postgres
```

**⚠ Since prepared statements cannot be used in table names, SQL injection may occur depending on the value of the option.**

@k1LoW 
Validation of table names may be useful to prevent this (i.e., limit them to alphanumeric characters and underscores, etc).
I don't think this measure is necessary since the value is crossed via the option, what do you think?

