### PR TITLE
add --sources options

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,13 +33,14 @@ import (
 )
 
 var (
-	quiet      bool
-	light      bool
-	skipInit   bool
-	skipUpdate bool
-	cacheDir   string
-	vulnerabilitiesTableName   string
-	adivisoryTableName   string
+	quiet                    bool
+	light                    bool
+	skipInit                 bool
+	skipUpdate               bool
+	cacheDir                 string
+	vulnerabilitiesTableName string
+	adivisoryTableName       string
+	sources                  []string
 )
 
 var rootCmd = &cobra.Command{
@@ -65,7 +66,7 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
-		if err := internal.UpdateDB(ctx, cacheDir, dsn, vulnerabilitiesTableName, adivisoryTableName); err != nil {
+		if err := internal.UpdateDB(ctx, cacheDir, dsn, vulnerabilitiesTableName, adivisoryTableName, sources); err != nil {
 			return err
 		}
 
@@ -96,6 +97,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&cacheDir, "cache-dir", "", "", "cache dir")
 	rootCmd.Flags().StringVarP(&vulnerabilitiesTableName, "vulnerabilities-table-name", "", "vulnerabilities", "Vulnerabilities Table Name")
 	rootCmd.Flags().StringVarP(&adivisoryTableName, "advisory-table-name", "", "vulnerability_advisories", "Vulnerability Advisories Table Name")
+	rootCmd.Flags().StringArrayVarP(&sources, "sources", "", nil, "Vulnerability Sources")
 }
 
 func cacheDirPath() string {

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -89,7 +89,7 @@ func InitDB(ctx context.Context, dsn, vulnerabilityTableName, advisoryTableName 
 	return nil
 }
 
-func UpdateDB(ctx context.Context, cacheDir, dsn, vulnerabilityTableName, advisoryTableName string) error {
+func UpdateDB(ctx context.Context, cacheDir, dsn, vulnerabilityTableName, advisoryTableName string, targetSources []string) error {
 	_, _ = fmt.Fprintf(os.Stderr, "%s", "Updating vulnerability information tables ... \n")
 	var (
 		driver drivers.Driver
@@ -169,6 +169,20 @@ func UpdateDB(ctx context.Context, cacheDir, dsn, vulnerabilityTableName, adviso
 			if s == "trivy" || s == "vulnerability" {
 				return nil
 			}
+
+			if len(targetSources) > 0 {
+				found := false
+				for _, ts := range targetSources {
+					if strings.Contains(s, ts) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					return nil
+				}
+			}
+
 			_, _ = fmt.Fprintf(os.Stderr, ">>> %s\n", s)
 			c := b.Cursor()
 			vulnds := [][][]byte{}


### PR DESCRIPTION
Hi @k1LoW 

This PR is ad add `--sources` option.
If `--source <vulnerability source name>` is specified, only `<vulnerability source name>`  will be imported to DB.

## sample usage

If you want only `ubuntu` vulnerabilities',  just specify `--sources ubuntu`. 

```sh
 $ ./trivy-db-to --sources="ubuntu" ... snip
Fetching and updating Trivy DB ... done (already exist)
Initializing vulnerability information tables ... done
Updating vulnerability information tables ... 
>> Updating table 'trivy_vulnerabilities' ...
>> Updating table 'trivy_vulnerability_advisories' ...
>>> ubuntu 12.04
>>> ubuntu 12.10
>>> ubuntu 13.04
>>> ubuntu 13.10
>>> ubuntu 14.04
>>> ubuntu 14.10
>>> ubuntu 15.04
>>> ubuntu 15.10
>>> ubuntu 16.04
>>> ubuntu 16.10
>>> ubuntu 17.04
>>> ubuntu 17.10
>>> ubuntu 18.04
>>> ubuntu 18.10
>>> ubuntu 19.04
>>> ubuntu 19.10
>>> ubuntu 20.04
>>> ubuntu 20.10
>>> ubuntu 21.04
>>> ubuntu 21.10
done
```

## 日本語で 🙏 

特定の脆弱性のソースだけあれば十分というケースがあって、ソースを選択できるオプションを足す PR を出しています

 * 開発環境等で脆弱性情報の seed として使いたいが、全部のソースを入れると (少し) 時間がかかるからソースを絞りたい
 * 脆弱性を管理する上で取り扱うことのないソースを除外したい
 * ... etc

### 相談したいこと

 * とりあえずオプション名は `--sources` としてますが、他 いい名前があれば
   * 複数指定できるオプションですが、複数形がいいのか、単数系がいいのか


